### PR TITLE
fix E118: Too many arguments for function: taglist

### DIFF
--- a/plugin/python-imports.vim
+++ b/plugin/python-imports.vim
@@ -237,7 +237,7 @@ function! ImportName(name, here, stay)
         " Let's see if we have one tag, or multiple tags (in which case we'll
         " let the user decide)
         let tag_rx = "^\\C" . l:name . "\\([.]py\\)\\=$"
-        let found = taglist(tag_rx, expand("%"))
+        let found = taglist(tag_rx)
         if found == []
             " Give up and bail out
            echohl Error | echomsg "Tag not found:" l:name | echohl None


### PR DESCRIPTION
Hi there,
I loved the simplicity of the plugin but couldn't get it to work directly due to the added parameter.
Looks like this was added after VIM 8.0, please let me know if there's a good way to make this more compatible in both directions. :)