### PR TITLE
Finding module using `python_paths` variable

### DIFF
--- a/autoload/pythonimports.vim
+++ b/autoload/pythonimports.vim
@@ -7,24 +7,17 @@ function! pythonimports#filename2module(filename)
   let pkg = fnamemodify(a:filename, ":p")
   let root = fnamemodify(pkg, ":h")
 
-  "normalize  paths
-  let _tmp = []
-  for path in g:pythonPaths
-    call add(_tmp, expand(path:p))
-  endfor
-  let g:pythonPaths = _tmp
-
   let found_dir = ""
   let found_path = ""
   while root != ""
-    if index(g:pythonPaths, root:p) != -1
+    if index(g:pythonPathsNorm, root) != -1
       let found_path = root
       break
     endif
     if found_dir == "" && !filereadable(root . "/__init__.py")
       let found_dir = root
       " note: can't break here!  PEP 420 implicit namespace packages don't have __init__.py,
-      " so we might find the actual package root in a parent directory beyond this one, via g:pythonPaths
+      " so we might find the actual package root in a parent directory beyond this one, via g:pythonPathsNorm
     endif
     let root = fnamemodify(root, ":h")
   endwhile

--- a/autoload/pythonimports.vim
+++ b/autoload/pythonimports.vim
@@ -7,17 +7,24 @@ function! pythonimports#filename2module(filename)
   let pkg = fnamemodify(a:filename, ":p")
   let root = fnamemodify(pkg, ":h")
 
+  "normalize  paths
+  let pythonPathsNorm = []
+  for path in g:pythonPaths
+    let path_without_slash = substitute(expand(path), "/$", "", "")
+    call add(pythonPathsNorm, path_without_slash)
+  endfor
+
   let found_dir = ""
   let found_path = ""
   while root != ""
-    if index(g:pythonPathsNorm, root) != -1
+    if index(pythonPathsNorm, root) != -1
       let found_path = root
       break
     endif
     if found_dir == "" && !filereadable(root . "/__init__.py")
       let found_dir = root
       " note: can't break here!  PEP 420 implicit namespace packages don't have __init__.py,
-      " so we might find the actual package root in a parent directory beyond this one, via g:pythonPathsNorm
+      " so we might find the actual package root in a parent directory beyond this one, via pythonPathsNorm
     endif
     let root = fnamemodify(root, ":h")
   endwhile

--- a/autoload/pythonimports.vim
+++ b/autoload/pythonimports.vim
@@ -9,22 +9,13 @@ function! pythonimports#filename2module(filename)
 
   let found = 0
   if exists("g:python_paths")
-      for path in g:python_paths
-            if root =~ path
-                "path detected
-                while strlen(root)
-                    if root == path
-                        "echo 'found '. root
-                        let found = 1
-                        break
-                    endif
-                    let root = fnamemodify(root, ":h")
-                endwhile
-            endif
-            if found
-                break
-            endif
-      endfor
+    for path in g:python_paths
+      if root =~ path
+        let root = path
+        let found = 1
+        break
+      endif
+    endfor
   endif
 
   if !found

--- a/autoload/pythonimports.vim
+++ b/autoload/pythonimports.vim
@@ -6,12 +6,35 @@ function! pythonimports#filename2module(filename)
   " directly included in PYTHONPATH.
   let pkg = fnamemodify(a:filename, ":p")
   let root = fnamemodify(pkg, ":h")
-  while strlen(root)
-    if !filereadable(root . "/__init__.py")
-      break
-    endif
-    let root = fnamemodify(root, ":h")
-  endwhile
+
+  let found = 0
+  if exists("g:python_paths")
+      for path in g:python_paths
+            if root =~ path
+                "path detected
+                while strlen(root)
+                    if root == path
+                        "echo 'found '. root
+                        let found = 1
+                        break
+                    endif
+                    let root = fnamemodify(root, ":h")
+                endwhile
+            endif
+            if found
+                break
+            endif
+      endfor
+  endif
+
+  if !found
+    while strlen(root)
+      if !filereadable(root . "/__init__.py")
+        break
+      endif
+      let root = fnamemodify(root, ":h")
+    endwhile
+  endif
   let pkg = strpart(pkg, strlen(root))
   " Convert the relative path into a Python dotted module name
   let pkg = substitute(pkg, "[.]py$", "", "")

--- a/autoload/pythonimports.vim
+++ b/autoload/pythonimports.vim
@@ -7,17 +7,24 @@ function! pythonimports#filename2module(filename)
   let pkg = fnamemodify(a:filename, ":p")
   let root = fnamemodify(pkg, ":h")
 
+  "normalize  paths
+  let _tmp = []
+  for path in g:pythonPaths
+    call add(_tmp, expand(path:p))
+  endfor
+  let g:pythonPaths = _tmp
+
   let found_dir = ""
   let found_path = ""
   while root != ""
-    if index(g:python_paths, root) != -1
+    if index(g:pythonPaths, root:p) != -1
       let found_path = root
       break
     endif
     if found_dir == "" && !filereadable(root . "/__init__.py")
       let found_dir = root
       " note: can't break here!  PEP 420 implicit namespace packages don't have __init__.py,
-      " so we might find the actual package root in a parent directory beyond this one, via g:python_paths
+      " so we might find the actual package root in a parent directory beyond this one, via g:pythonPaths
     endif
     let root = fnamemodify(root, ":h")
   endwhile

--- a/plugin/python-imports.vim
+++ b/plugin/python-imports.vim
@@ -115,7 +115,7 @@ if !exists("g:pythonBuiltinModules")
 endif
 
 if !exists("g:pythonPaths")
-    let g:pythonPathsNorm = []
+    let g:pythonPaths = []
 endif
 
 

--- a/plugin/python-imports.vim
+++ b/plugin/python-imports.vim
@@ -114,6 +114,10 @@ if !exists("g:pythonBuiltinModules")
           \ }
 endif
 
+if !exists("g:pythonPaths")
+    let g:pythonPaths = []
+endif
+
 if v:version >= 801 || v:version == 800 && has("patch-499")
     function! s:taglist(tag, filename)
         return taglist(a:tag, a:filename)

--- a/plugin/python-imports.vim
+++ b/plugin/python-imports.vim
@@ -116,14 +116,6 @@ endif
 
 if !exists("g:pythonPaths")
     let g:pythonPathsNorm = []
-else
-  "normalize  paths
-  let _tmp = []
-  for path in g:pythonPaths
-    let path_without_slash = substitute(expand(path), "/$", "", "")
-    call add(_tmp, path_without_slash)
-  endfor
-  let g:pythonPathsNorm = _tmp
 endif
 
 

--- a/plugin/python-imports.vim
+++ b/plugin/python-imports.vim
@@ -115,8 +115,17 @@ if !exists("g:pythonBuiltinModules")
 endif
 
 if !exists("g:pythonPaths")
-    let g:pythonPaths = []
+    let g:pythonPathsNorm = []
+else
+  "normalize  paths
+  let _tmp = []
+  for path in g:pythonPaths
+    let path_without_slash = substitute(expand(path), "/$", "", "")
+    call add(_tmp, path_without_slash)
+  endfor
+  let g:pythonPathsNorm = _tmp
 endif
+
 
 if v:version >= 801 || v:version == 800 && has("patch-499")
     function! s:taglist(tag, filename)


### PR DESCRIPTION
With this edits I can properly select module root, even if  `__init__.py` file is not inside.

Reference - https://stackoverflow.com/questions/37139786/is-init-py-not-required-for-packages-in-python-3-3

You need to define python_paths global variable, e.g.
```
let g:python_paths = [
             \ '/home/arthur/project',
             \ ]
```
I've not strongly tested this PR. (It works on my project)