### PR TITLE
Update the README. Emphasize the usefulness of pythonPaths setting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ could be used ::
         \ ]
 
 Note that the ``expand()`` is used here so that the Home directory (``~``)
-to be interpreted correctly.
+will be interpreted correctly.
 
 
 Copyright

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,37 @@ supported, if you use one name per line, i.e. ::
     )
 
 
+Special Paths
+-------------
+
+Aside from the project root path, some projects auto-import its sub-folders also
+in the Python path (e.g. ``apps`` or ``conf`` folders) which is usually done to
+avoid repetitive or lengthy import names. For instance,
+a project that is located in ``~/my_project`` could have an ``apps`` folder
+which has this logical structure ::
+
+    from apps.alpha import bravo
+    from apps.charlie import delta
+
+But, the project team might decide to auto-import the ``apps`` folder
+in the environment setup, so that the code will have this import format
+for convenience ::
+
+    from alpha import bravo
+    from charlie import delta
+
+To resolve these special imports correctly, the ``pythonPaths`` global variable
+could be used ::
+
+    let g:pythonPaths = [
+        \ expand('~/my_project/apps'),
+        \ expand('~/my_project/conf'),
+        \ ]
+
+Note that the ``expand()`` is used here so that the Home directory (``~``)
+to be interpreted correctly.
+
+
 Copyright
 ---------
 


### PR DESCRIPTION
Created this MR since this is the exact use case pestering me for some time already, which I thought is not supported since I just based on the README before. So, tried to dig the code recently, and found out that I could leverage the `pythonPaths` setting which is the exact feature that I want for our project, since some of the paths are not imported by the plugin correctly due to their special locations (even though they are sub-folders of the project root). Other devs might have the same question/use case as well.

PS: Thanks for this really handy plugin. :)